### PR TITLE
docs: use `addResourceBundle` in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ i18n.use(LanguageDetector)
 
 supportedLngs.forEach((lang) => {
     ns.forEach((n) => {
-        i18n.addResources(
+        i18n.addResourceBundle(
             lang,
             n,
             require(`../public/locales/${lang}/${n}.json`)


### PR DESCRIPTION
I stumbled upon this while setting up storybook for our project. The example uses `addResources` to load external json files. A typical json file is probably nested and requires `addResourceBundle` to load, otherwise any object with nested keys will be silently ignored.

The [documentation](https://www.i18next.com/overview/api#addresources) is kind of telling the facts but not very explaining. Instead I share the relevant sourcecode for the involved methods I'm referring to:
https://github.com/i18next/i18next/blob/9ad73d5e029eec70935b526a458f80bea4561b17/src/ResourceStore.js#L89-L128

Actually `addResourceBundle` seems to supersedes `addResources` as it can load both nested and plain keys:


```
supportedLngs.forEach((lang) => {
  i18n.addResourceBundle(
    lang,
    "translations",
    {
      "foo.bar": "works ✅",
      foo: {
        bar: "works too ✅"
      }
    }
  );
});
```

in difference to `addResources` where the nested part is ignored as it's an object:

```
supportedLngs.forEach((lang) => {
  i18n.addResources(
    lang,
    "translations",
    {
      "foo.bar": "works ✅",
      foo: {
        bar: "will not work ⛔️"
      }
    }
  );
});
```

I'm proposing this change to file at least some record in this repo. I'm happy to merge it if you agree. 
If you had reasons to use `addResources` I would like to know the reasoning as well and then we can close this PR.

Thank you for providing this easy way of integrating i18next in storybook. Very much appreciated 🌟