### PR TITLE
Fix i18n and Storybook Play interactions

### DIFF
--- a/src/withI18Next.tsx
+++ b/src/withI18Next.tsx
@@ -36,14 +36,11 @@ export const withI18Next = (
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [locale]);
 
-    if (i18n && show) {
-        return (
-            <Fragment key={locale}>
-                <I18nextProvider i18n={i18n}>
-                    {story(context) as ReactNode | null}
-                </I18nextProvider>
-            </Fragment>
-        );
-    }
-    return story(context);
+    return (
+        <>
+            <I18nextProvider i18n={i18n}>
+                {story(context) as ReactNode | null}
+            </I18nextProvider>
+        </>
+    );
 };

--- a/src/withI18Next.tsx
+++ b/src/withI18Next.tsx
@@ -16,24 +16,11 @@ export const withI18Next = (
     } = context;
 
     const [{locale}] = useGlobals();
-    const [show, setShow] = useState(true);
-    const timeoutRef = useRef(null);
 
     useEffect(() => {
         if (locale) {
-            if (timeoutRef.current) {
-                clearTimeout(timeoutRef.current);
-            }
-            setShow(false);
             i18n?.changeLanguage(locale);
-            timeoutRef.current = setTimeout(() => setShow(true), 100);
-            return () => {
-                if (timeoutRef.current) {
-                    clearTimeout(timeoutRef.current);
-                }
-            };
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [locale]);
 
     return (


### PR DESCRIPTION
Storybook play was breaking when the locale was changing because it rendered a different instance of `story(context)`