### PR TITLE
add friendly error message if i18n is undefined

### DIFF
--- a/src/withI18Next.tsx
+++ b/src/withI18Next.tsx
@@ -15,6 +15,14 @@ export const withI18Next = (
         parameters: {i18n},
     } = context;
 
+    if (i18n === undefined) {
+        console.error(`The 'i18n' parameter is missing in 'parameters' configuration of preview.js. Define the 'i18n' parameter as follows:
+parameters: {
+    i18n,
+},
+`);
+    }
+
     const language = i18n?.language;
 
     const [{locale}] = useGlobals();


### PR DESCRIPTION
Thank you for a great package!

Since the `i18n` argument of `I18nextProvider` is an optional argument, no error occurs even if `i18n` is undefined. 
ref: https://react.i18next.com/latest/i18nextprovider

This will take time until the developer realizes the parameters are incorrectly set.
To solve this problem, I have improved the display of a friendly error message.